### PR TITLE
Added a setup.py, auto-detect subdir/arch, allow insecure server (for debug, or easy proxy behind nginx), update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, SciTools-incubator
+Copyright (c) 2018, Met Office.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -27,8 +27,26 @@ optional arguments:
                         hash of secure token
 ```
 
+### Basic Usage Example
 
-### Usage Example 
+To start an insecure webserver that will write packages to a conda channel in the
+given directory:
+
+```
+$ conda-upload-server -d /path/to/channel
+```
+
+To test the webserver:
+
+```
+curl -F 'artifact=@/path/to/conda/binary/package.tar.bz2' --fail http://localhost:8080/
+```
+
+This will create a conda channel in /path/to/channel/<package-platform>/, with the
+appropriate channel (``repodata.json``) content.
+
+
+### Secure Usage Example
 
 For example, to start a secure webserver running on port 9999 that will write
 linux-64 packages to the (imaginary) conda channel at ``/path/to/conda/channel``:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use, simply clone this repo and run the Python webserver, observing the
 ## Usage
 
 ```
-usage: artifact_upload_handler.py [-h] -d WRITE_DIR -p PORT -e CONDA_EXE -c
+usage: conda-upload-server [-h] -d WRITE_DIR -p PORT -e CONDA_EXE -c
                                   CERTFILE -k KEYFILE -t TOKEN_HASH
 
 optional arguments:
@@ -34,12 +34,12 @@ For example, to start a secure webserver running on port 9999 that will write
 linux-64 packages to the (imaginary) conda channel at ``/path/to/conda/channel``:
 
 ```
-$ python artifact_upload_handler.py -d /path/to/conda/channel/linux-64 \
-                                    -p 9999 \
-                                    -e /path/to/env/bin/conda \
-                                    -c /path/to/mycertfile.crt \
-                                    -k /path/to/mykeyfile.key \
-                                    -t eccd989b
+$ conda-upload-server -d /path/to/conda/channel/linux-64 \
+                       -p 9999 \
+                       -e /path/to/env/bin/conda \
+                       -c /path/to/mycertfile.crt \
+                       -k /path/to/mykeyfile.key \
+                       -t eccd989b
 
 ```
 

--- a/conda_upload_server/cli.py
+++ b/conda_upload_server/cli.py
@@ -1,0 +1,5 @@
+from . import handler
+
+
+def main():
+    return handler.main()

--- a/conda_upload_server/handler.py
+++ b/conda_upload_server/handler.py
@@ -81,7 +81,7 @@ def make_app(write_path, conda_exe, token_hash):
     return tornado.web.Application([(r'/', ArtifactUploadHandler, kw)])
 
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--write_dir",
                         help="directory to write artifacts to",
@@ -121,3 +121,7 @@ if __name__ == '__main__':
     https_server = tornado.httpserver.HTTPServer(app, ssl_options=ssl_opts)
     https_server.listen(port)
     tornado.ioloop.IOLoop.current().start()
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_upload_server/token.py
+++ b/conda_upload_server/token.py
@@ -1,0 +1,57 @@
+import argparse
+import distutils.spawn
+import hashlib
+import hmac
+import io
+import json
+import logging
+import os
+import subprocess
+import tarfile
+
+
+#: A default salt is provided, but it is recommended to use your own.
+DEFAULT_SALT = '42679ad04d44c96ed27470c02bfb28c3'
+
+
+def generate_hash(token, *, salt=DEFAULT_SALT):
+    to_hash = '{}{}'.format(salt, token)
+    return hashlib.sha256(to_hash.encode('utf-8')).hexdigest()
+
+
+def check_token(hash_expected, salt, token):
+    """Check we have been passed the correct secure token."""
+    if hash_expected:
+        hash_result = generate_hash(salt=salt, token=token)
+        # Reduce the risk of timing analysis attacks.
+        result = hmac.compare_digest(hash_expected, hash_result)
+    else:
+        assert token is None
+        result = True
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--salt",
+                        help="The (semi-)secret salt being used by the server",
+                        default=DEFAULT_SALT,
+                        )
+    parser.add_argument("token",
+                        help="The secret token/password made available to the client in plain-text",
+                        )
+
+    args = parser.parse_args()
+    
+    server_token = generate_hash(salt=args.salt, token=args.token)
+
+    print('Server salt:  "{}"'.format(args.salt))
+    print('Client token: "{}"'.format(args.token))
+    print('Server token: "{}"'.format(server_token))
+
+    assert check_token(server_token, args.salt, args.token)
+
+    
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+from codecs import open
+from os import path
+from setuptools import setup, find_packages
+
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+setup(
+    name='conda-upload-server',
+    version='1.0',
+    description='A lightweight webservice capable of updating a local conda channel',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/SciTools-incubator/artifact-upload-handler',
+
+    author='SciTools contributors',
+    author_email='scitools-iris-dev@googlegroups.com',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+    ],
+
+    keywords='conda upload channel',
+    packages=find_packages(),
+
+    install_requires=['tornado'],
+
+    entry_points={  # Optional
+        'console_scripts': [
+            'conda-upload-server=conda_upload_server.cli:main',
+        ],
+    },
+
+    project_urls={
+        'Source': 'https://github.com/SciTools-incubator/artifact-upload-handler',
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ setup(
     keywords='conda upload channel',
     packages=find_packages(),
 
-    install_requires=['tornado'],
+    python_requires='>=3.5',
+    install_requires=[
+        'tornado'],
 
     entry_points={  # Optional
         'console_scripts': [


### PR DESCRIPTION
Sorry it is a bit of a mammoth PR - there were a few changes that enabled others, and it was quite hard to separate. 

In this PR

 - [x] make the thing installable with a setup.py
 - [x] make it possible to run an unsecured server (useful for nginx proxy, and delegating auth elsewhere)
 - [x] auto-detect the arch/subdir, rather than allowing the client to tell you where it should go (cc @bjlittle)
 - [x] split off the token authentication into its own module, and provide a CLI to allow users to get the tokens easily
 - [x] update the README to provide details on how to run a basic server
 - [x] update the README to provide details on how to create authentication tokens